### PR TITLE
Moved duckdb and edited build dir

### DIFF
--- a/reports/package.json
+++ b/reports/package.json
@@ -2,7 +2,7 @@
   "name": "my-evidence-project",
   "version": "0.0.1",
   "scripts": {
-    "build": "EVIDENCE_BUILD_DIR=./build/my-evidence-app evidence build",
+    "build": "EVIDENCE_BUILD_DIR=./build/strava_datastack evidence build",
     "build:strict": "evidence build:strict",
     "dev": "evidence dev --open /",
     "test": "evidence build",

--- a/reports/pages/goals.md
+++ b/reports/pages/goals.md
@@ -11,7 +11,7 @@ title: Goals
       , sum(total_distance)    AS total_distance_month
       , sum(total_moving_time) AS total_moving_time
       , sum(total_distance_month) over (partition by activity_year, sport_type) AS total_distance_year
-    FROM strava_datastack.activities_by_day
+    FROM strava_source.activities_by_day
     WHERE sport_type = 'Run'
     GROUP BY 1, 2, 3
     ORDER BY activity_month DESC
@@ -23,7 +23,7 @@ title: Goals
       , sum(activities_cnt)    AS activities_cnt
       , sum(total_distance)    AS total_distance
       , sum(total_moving_time) AS total_moving_time
-    FROM strava_datastack.activities_by_day
+    FROM strava_source.activities_by_day
     WHERE sport_type = 'Run'
     GROUP BY 1, 2
     ORDER BY activity_year DESC

--- a/reports/pages/index.md
+++ b/reports/pages/index.md
@@ -7,14 +7,14 @@ hideSidebar: true
 ```sql sport_types
   select distinct
       sport_type
-  from strava_datastack.activities_by_day
+  from strava_source.activities_by_day
   where sport_type is not null
 ```
 
 ```sql all_activities_by_day
    SELECT
     *
-  FROM strava_datastack.activities_by_day
+  FROM strava_source.activities_by_day
   GROUP BY ALL
 ```
 

--- a/reports/sources/strava_source/activities_by_day.sql
+++ b/reports/sources/strava_source/activities_by_day.sql
@@ -6,5 +6,5 @@ SELECT
 , count(1) AS activities_cnt
 , sum(distance) AS total_distance
 , sum(moving_time) AS total_moving_time
-FROM strava_datastack.strava_dev.reporting_all_activities
+FROM strava_dev.reporting_all_activities
 GROUP BY ALL

--- a/reports/sources/strava_source/connection.yaml
+++ b/reports/sources/strava_source/connection.yaml
@@ -1,8 +1,8 @@
 # This file was automatically generated
-name: strava_datastack
+name: strava_source
 type: duckdb
 options:
-  filename: strava_datastack.duckdb
+  filename: ../../../strava_datastack.duckdb
 #
 #name: needful_things
 #type: duckdb


### PR DESCRIPTION
The "strava_datastack" not found error may have been causing a NULL build. This PR deletes strava_datastack.duckdb from /source/strava_source and repoints the connection.yml to root strava_datastack.duckdb.

Another issue may be the build directory - changed to /build/strava_datastack in package.json.